### PR TITLE
Create file

### DIFF
--- a/gui/djvj-GUI.py
+++ b/gui/djvj-GUI.py
@@ -1,13 +1,21 @@
-from tkinter import *
-from tkinter import filedialog, messagebox
-import tkinter as tk
-import time
+"""
+Runs the GUI for the DJ-VJ app.
+Displays a splash screen, then Create and Load Show buttons
+Create Show screen functionality is built out, more to come!
+"""
 import pickle
+import tkinter as tk
+from tkinter import filedialog, messagebox, Button, Label, Entry, Canvas, PhotoImage,\
+                    StringVar, OptionMenu, NW, END
+import time
 
-# global variable params, not sure where this is actually supposed to go but for right now it only works up here
-params = ""
+# global variable params, not sure where this is actually supposed to go
+# but for right now it only works up here
+Params = ""
 
-# the splash screen for DJ-VJ
+"""
+Displays the splash screen with the DJ-VJ loading screen
+"""
 class SplashScreen(tk.Toplevel):
     def __init__(self, parent):
         tk.Toplevel.__init__(self, parent)
@@ -20,13 +28,17 @@ class SplashScreen(tk.Toplevel):
         img = PhotoImage(file="dj-vj.gif")
         canvas.create_image(30, 120, anchor=NW, image=img)
         # adds the "loading" label that makes it splash-screenish
-        self.label = Label(self, text="Loading....", bg="#212121", fg="#05F72D", font=("Courier", 72))
+        self.label = Label(self, text="Loading....", bg="#212121",
+                           fg="#05F72D", font=("Courier", 72))
         self.label.place(relx=.5, rely=.12, anchor="center")
         # forces this window to be shown
         self.update()
 
 
-# the main screen
+"""
+The main navigation screen, which has the "Create Screen" and "Load Screen" buttons
+"""
+
 class IntroScreen(tk.Tk):
     def __init__(self):
         tk.Tk.__init__(self)
@@ -39,16 +51,17 @@ class IntroScreen(tk.Tk):
         self.attributes('-fullscreen', True)
 
         # this creates text and customizes it
-        self.label = Label(self, text="Welcome to DJ-VJ!", bg="#212121", fg="#05F72D", font=("Courier", 72))
+        self.label = Label(self, text="Welcome to DJ-VJ!", bg="#212121",
+                           fg="#05F72D", font=("Courier", 72))
         # sets it in the middle of the screen, about 1/4 of the way down
         self.label.place(relx=.5, rely=.25, anchor="center")
 
         # creates the buttons for create, load, and use default show
-        self.create_button = Button(self, text="Create\nShow", highlightbackground='#05F72D', fg="#05F72D",
+        self.create_button = Button(self, text="Create\nShow", bg='#05F72D', fg="#05F72D",
                                     font=("Courier", 48), height=5, width=10, command=self.create)
         self.create_button.place(relx=.33, rely=.75, anchor="center")
 
-        self.load_button = Button(self, text="Load\nShow", highlightbackground='#05F72D', fg="#05F72D",
+        self.load_button = Button(self, text="Load\nShow", bg='#05F72D', fg="#05F72D",
                                   font=("Courier", 48), height=5, width=10, command=self.load)
         self.load_button.place(relx=.66, rely=.75, anchor="center")
 
@@ -68,10 +81,12 @@ class IntroScreen(tk.Tk):
         # self.deiconify()
 
     # defines what happens when you click on load
-    # right now, only lets you select .djvj files and prints out the data that's in them. will do more later
+    # right now, only lets you select .djvj files, prints out the data
+    # will do more later
     def load(self):
         filename = filedialog.askopenfilename(initialdir="/home/Documents", title="Select Show",
-                                              filetypes=(("djvj files", "*.djvj"), ("all files", "*.*")))
+                                              filetypes=(("djvj files", "*.djvj"),
+                                                         ("all files", "*.*")))
         data = pickle.load(open("%s" % filename, "rb"))
         messagebox.showinfo("Load Show", data)
         print(data)
@@ -80,7 +95,12 @@ class IntroScreen(tk.Tk):
     def create(self):
         CreateScreen(self)
 
-# lets user create a .djvj file and add parameters to their show
+
+"""
+Users can create a .djvj file by adding parameters and setting target values
+They can also specify the file name/file save location when saving
+"""
+
 class CreateScreen(tk.Toplevel):
     def __init__(self, parent):
         tk.Toplevel.__init__(self, parent)
@@ -90,11 +110,11 @@ class CreateScreen(tk.Toplevel):
         # makes fullscreen
         self.attributes('-fullscreen', True)
 
-        Label(self, text="Create a Show! Add Parameters: ", bg="#212121", fg="#05F72D", font=("Courier", 36)) \
-            .place(relx=.5, rely=.1, anchor="center")
+        Label(self, text="Create a Show! Add Parameters: ", bg="#212121",
+              fg="#05F72D", font=("Courier", 36)).place(relx=.5, rely=.1, anchor="center")
 
-        Label(self, text="If", bg="#212121", fg="#05F72D", font=("Courier", 36)).place(relx=.35, rely=.25,
-                                                                                       anchor="center")
+        Label(self, text="If", bg="#212121", fg="#05F72D",
+              font=("Courier", 36)).place(relx=.35, rely=.25, anchor="center")
         # the sound attribute being tracked
         self.attr = StringVar(self)
         self.attr.set("           ")  # default value
@@ -109,13 +129,16 @@ class CreateScreen(tk.Toplevel):
         self.e1 = Entry(self)
         self.e1.place(relx=.6, rely=.25, anchor="center")
 
-        Label(self, text=":", bg="#212121", fg="#05F72D", font=("Courier", 36)).place(relx=.65, rely=.25,
-                                                                                      anchor="center")
+        Label(self, text=":", bg="#212121", fg="#05F72D", font=("Courier", 36)) \
+            .place(relx=.65, rely=.25, anchor="center")
 
         # buttons
-        Button(self, text='Add Param', command=self.addition).place(relx=.45, rely=.35, anchor="center")
-        Button(self, text='Remove Param', command=self.remove).place(relx=.55, rely=.35, anchor="center")
-        Button(self, text='Create File', command=self.createFile).place(relx=.5, rely=.43, anchor="center")
+        Button(self, text='Add Param', command=self.addition)\
+            .place(relx=.45, rely=.35, anchor="center")
+        Button(self, text='Remove Param', command=self.remove)\
+            .place(relx=.55, rely=.35, anchor="center")
+        Button(self, text='Create File', command=self.create_file)\
+            .place(relx=.5, rely=.43, anchor="center")
 
         # shows running params
         self.display = Label(self, text="", bg="#212121", fg="#05F72D", font=("Courier", 20))
@@ -126,22 +149,25 @@ class CreateScreen(tk.Toplevel):
         if self.attr.get() == "" or self.sign.get() == "" or self.e1.get() == "":
             messagebox.showinfo("Error", "Please fill out all fields.")
             return
-        global params
-        params = params + "\n" + "If " + self.attr.get() + " " + self.sign.get() + " " + self.e1.get()
-        self.paramsAdded()
+        global Params
+        Params = Params + "\n" + "If " + self.attr.get() + \
+                 " " + self.sign.get() + " " + self.e1.get()
+        self.params_added()
         # clears all the fields
         self.e1.delete(0, END)
         self.attr.set("          ")
         self.sign.set(" ")
 
     # creates the show file
-    def createFile(self):
-        global params
+    def create_file(self):
+        global Params
         # lets user choose name/save location
-        filename = filedialog.asksaveasfilename(initialdir="/home/Documents", title="Save file location",
-                                                filetypes=(("djvj files", "*.djvj"), ("all files", "*.*")))
+        filename = filedialog.asksaveasfilename(initialdir="/home/Documents",
+                                                title="Save file location",
+                                                filetypes=(("djvj files", "*.djvj"),
+                                                           ("all files", "*.*")))
         # adds to file
-        pickle.dump(params, open("%s.djvj" % filename, "wb"))
+        pickle.dump(Params, open("%s.djvj" % filename, "wb"))
         # unnecessary rn, just shows that data stays the same
         data = pickle.load(open("%s.djvj" % filename, "rb"))
         print(data)
@@ -150,20 +176,20 @@ class CreateScreen(tk.Toplevel):
         self.destroy()
 
     # shows running total of params to be added
-    def paramsAdded(self):
-        global params
-        self.display.configure(text="%s" % params)
+    def params_added(self):
+        global Params
+        self.display.configure(text="%s" % Params)
 
     # will remove last param added
     def remove(self):
-        global params
+        global Params
         # basic error checking
-        if params == "":
+        if Params == "":
             messagebox.showinfo("Error", "Parameters are empty!")
-        idx = params.rfind("\n")
+        idx = Params.rfind("\n")
         if idx >= 0:
-            params = params[:idx]
-        self.paramsAdded()
+            Params = Params[:idx]
+        self.params_added()
 
-my_gui = IntroScreen()
-my_gui.mainloop()
+
+IntroScreen().mainloop()


### PR DESCRIPTION
Closes #18 
## Description
Allows the user to create a new .djvj show file by adding parameters relating to pitch, amplitude, and tempo. Users can save the .djvj in the location of their choosing, and load it using the "Load Show" button.
## Test
`cd gui/`
`python3 djvj-GUI.py`
Select _Create Show_
Add parameters, remove parameters
Select _Create File_, save where desired
Select _Load Show_, choose created file
## Expected Results
Message box will pop up with the contents of created .djvj show file
## Pylint Score
7.31/10
## Needs Work
* add selection of video file to play