### PR TITLE
Changed button text color so it should be visible

### DIFF
--- a/djvj/djvj_GUI.py
+++ b/djvj/djvj_GUI.py
@@ -151,11 +151,11 @@ class CreateScreen(tk.Toplevel):
             .place(relx=.65, rely=.25, anchor="center")
 
         # buttons
-        Button(self, text='Add Param', command=self.addition) \
+        Button(self, text='Add Param', fg="#000000", command=self.addition) \
             .place(relx=.45, rely=.35, anchor="center")
-        Button(self, text='Remove Param', command=self.remove) \
+        Button(self, text='Remove Param',fg="#000000", command=self.remove) \
             .place(relx=.55, rely=.35, anchor="center")
-        Button(self, text='Create File', command=self.create_file) \
+        Button(self, text='Create File',fg="#000000", command=self.create_file) \
             .place(relx=.5, rely=.43, anchor="center")
 
         # shows running params


### PR DESCRIPTION
## Issue
Closes #62 

## Description
Hopefully fixes the bug raised in #62 where the button text is not visible. Was not able to recreate the error on my machine, but adding the text color should stop it from being the default, so it should show up in black now.

## Test Plan
`python3 main.py`
Choose "Create Show"

## Expected Results
You should be able to read the buttons "Add Param", "Remove Param" and "Create File"

## Style Score
8.13/10

