### PR TITLE
Abby/squasher2

### DIFF
--- a/djvj/gui.py
+++ b/djvj/gui.py
@@ -104,8 +104,6 @@ class IntroScreen(tk.Tk):
         filename = filedialog.askopenfilename(initialdir="/home/Documents", title="Select Show",
                                               filetypes=(("djvj files", "*.djvj"),
                                                          ("all files", "*.*")))
-        messagebox.showinfo(
-            "Load a Show", "Loading the DJ-VJ show contents....")
         try:
             data = pickle.load(open("%s" % filename, "rb"))
         except pickle.UnpicklingError:
@@ -113,6 +111,8 @@ class IntroScreen(tk.Tk):
         except FileNotFoundError:
             messagebox.showerror("ERROR", "No .djvj file selected")
         if data != "":
+            messagebox.showinfo(
+                "Load a Show", "Loading the DJ-VJ show contents....")
             rule_list = data.split("\n")
             error = False   # not a invalid path
             rule_list.pop(0)


### PR DESCRIPTION
## Issue
Closes #147 
Closes #166 
Closes #167 

## Description
Adds a loading hint to Load Show, fixes error where removing a moment leaves the file path, and removes file path from displaying for each individual rule, as well as for each moment.

## Test Plan
Create a DJ-VJ file. Add a few rules, and then a new moment. Add a new rule to that moment, and then remove the created rule. Remove that new moment. Add another rule to the first moment. Create the file, and load the show.

## Expected Results
When adding rules to a moment, only the "If pitch > 100" form will show, not including the file path. When loading the show, a message box letting you know the data is being processed will pop up, and then once the file's contents are displayed, you can see that even though you added a new moment and then removed it, the rule has the filepath of the first moment.

## Style Score
8.54/10

## Bugs
Only if necessary, things that will need to be fixed in the future

## Future Plans
Where to go from here
